### PR TITLE
Timeout improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "JSONStream": "^1.0.7",
     "async": "^1.5.0",
+    "callback-timeout": "^2.0.0",
     "chance": "^0.8.0",
     "debug": "^2.2.0",
     "generic-pool": "^2.2.1",
@@ -46,7 +47,6 @@
     "node-phantom-simple": "baudehlo/node-phantom-simple#b783d8228bd6855281bf772e217498e041c48711",
     "once": "^1.3.3",
     "phantomjs": "^1.9.19",
-    "timeout-callback": "0.0.4",
     "urijs": "^1.17.0"
   },
   "devDependencies": {

--- a/src/Finder.js
+++ b/src/Finder.js
@@ -1,3 +1,6 @@
+'use strict'; // eslint-disable-line
+
+const Runnable = require('./Runnable.js');
 const genericAnchors = require('../finders/genericAnchors.js');
 
 /**
@@ -5,7 +8,7 @@ const genericAnchors = require('../finders/genericAnchors.js');
 *
 * @interface
 */
-class Finder {
+class Finder extends Runnable {
     /**
     * A method to get a function from that is evaluated within the web page to
     * discover links to follow.
@@ -13,14 +16,8 @@ class Finder {
     * The returned function should call back with an array of discovered URLs by calling
     * `window.callPhantom(error, urlArray)`.
     * If your method did not provoke an error, pass null as the first argument.
-    * You can also throw an error from your returned function.
-    * Console output from the returned function can be seen if DEBUG="*:debug" is enabled.
     *
-    * The time out of the returned function is controlled via {@link CrawlKit#timeout}.
-    *
-    * Keep in mind that finder functions run in the webpage (and as such are restricted to browser features).
-    * There are no node features available. Also, closures, etc. won't work.
-    * Write this function as if it was called inside a pretty old WebKit.
+    * The time out of the returned function is controlled via {@link Finder#timeout}.
     *
     * The returned function will be called immediately after page load.
     *

--- a/src/Runnable.js
+++ b/src/Runnable.js
@@ -1,0 +1,55 @@
+'use strict'; // eslint-disable-line
+
+const timeoutKey = Symbol();
+const DEFAULT_TIMEOUT = 10000;
+
+class Runnable {
+
+    /**
+    * A method to get a function from that is evaluated inm various ways.
+    *
+    * The returned function should call back with an result of any serializable kind by calling
+    * `window.callPhantom(error, result)`.
+    * If your method did not provoke an error, pass null as the first argument.
+    * You can also throw an error from your returned function.
+    * Console output from the returned function can be seen if DEBUG="*:debug" is enabled.
+    *
+    * The time out of the returned function is controlled via {@link Runnable#timeout}.
+    *
+    * Keep in mind that returned functions run in the webpage (and as such are restricted to browser features).
+    * There are no node features available. Also, closures, etc. won't work.
+    * Write this function as if it was called inside a pretty old WebKit.
+    *
+    * The returned function will be called immediately after page load.
+    *
+    * @return {Function} A function to be evaluated within the crawled webpage
+    */
+    getRunnable() {
+        return function noopFunction() {
+            window.callPhantom(null, undefined);
+        };
+    }
+
+    /**
+    * Optional. Getter/setter for the timeout of the method returned by {@link Runnable#getRunnable}.
+    *
+    * Values under zero are set to zero.
+    *
+    * @type {!integer}
+    * @default 10000 (10 seconds)
+    */
+    set timeout(num) {
+        this[timeoutKey] = parseInt(num, 10);
+    }
+
+    /**
+    * @ignore
+    */
+    get timeout() {
+        return Math.max(0, this[timeoutKey] || DEFAULT_TIMEOUT);
+    }
+}
+
+Runnable.DEFAULT_TIMEOUT = DEFAULT_TIMEOUT;
+
+module.exports = Runnable;

--- a/src/Runnable.js
+++ b/src/Runnable.js
@@ -1,6 +1,15 @@
 'use strict'; // eslint-disable-line
 
+/**
+* @private
+*/
 const timeoutKey = Symbol();
+
+/**
+* The default timeout for a runnable in ms.
+* @type {!integer}
+* @default 10000
+*/
 const DEFAULT_TIMEOUT = 10000;
 
 class Runnable {

--- a/src/Runner.js
+++ b/src/Runner.js
@@ -1,9 +1,13 @@
+'use strict'; // eslint-disable-line
+
+const Runnable = require('./Runnable.js');
+
 /**
 * A webpage runner blueprint
 *
 * @interface
 */
-class Runner {
+class Runner extends Runnable {
 
     /**
     * A method to get a function from that is evaluated within the web page and returns a result.
@@ -11,14 +15,8 @@ class Runner {
     * The returned function should call back with an result of any serializable kind by calling
     * `window.callPhantom(error, result)`.
     * If your method did not provoke an error, pass null as the first argument.
-    * You can also throw an error from your returned function.
-    * Console output from the returned function can be seen if DEBUG="*:debug" is enabled.
     *
-    * The time out of the returned function is controlled via {@link CrawlKit#timeout}.
-    *
-    * Keep in mind that returned functions run in the webpage (and as such are restricted to browser features).
-    * There are no node features available. Also, closures, etc. won't work.
-    * Write this function as if it was called inside a pretty old WebKit.
+    * The time out of the returned function is controlled via {@link Runner#timeout}.
     *
     * The returned function will be called immediately after page load, any defined {@link Finder} and other {@link Runner}s added before.
     *

--- a/src/index.js
+++ b/src/index.js
@@ -327,7 +327,6 @@ class CrawlKit {
     * @return {(Stream|Promise.<Object>)} By default a Promise object is returned that resolves to the result. If streaming is enabled it returns a JSON stream of the results.
     */
     crawl(shouldStream) {
-        const crawlTimer = new NanoTimer();
         let stream;
         if (shouldStream) {
             stream = JSONStream.stringifyObject();
@@ -341,7 +340,7 @@ class CrawlKit {
                 throw new Error(`Defined url '${this.url}' is not valid.`);
             }
             const seen = new Map();
-            crawlTimer.time((stopCrawlTimer) => {
+            new NanoTimer().time((stopCrawlTimer) => {
                 let addUrl;
                 const q = async.queue((scope, workerFinished) => {
                     scope.tries++;

--- a/src/index.js
+++ b/src/index.js
@@ -181,7 +181,10 @@ class CrawlKit {
     * or {@link CrawlKit#timeout} is hit.
     * When a PhantomJS instance crashes whilst crawling a webpage, this instance is shutdown
     * and replaced by a new one. By default the webpage that failed in such a way will be
-    * re-queued. This member controls how often that re-queueing happens.
+    * re-queued.
+    * If the finders and runners did not respond within the defined timeout,
+    * it will be tried to run them again as well.
+    * This member controls how often that re-queueing happens.
     *
     * Values under zero are set to zero.
     *
@@ -380,14 +383,14 @@ class CrawlKit {
                                 }
                             }
                             stopWorkerTimer();
-                            if (err instanceof HeadlessError) {
+                            if (err instanceof HeadlessError || err instanceof TimeoutError) {
                                 if (scope.tries < this.tries) {
                                     logger.info(`Retrying ${scope.url} - adding back to queue.`);
                                     delete scope.result.error;
                                     q.unshift(scope);
                                     return queueItemFinished();
                                 }
-                                logger.info(`${scope.url} crashed ${scope.tries} times. Giving up.`);
+                                logger.info(`Tried to crawl ${scope.url} ${scope.tries} times. Giving up.`);
                             }
                             if (shouldStream) {
                                 stream.write([scope.url, scope.result]);

--- a/src/index.js
+++ b/src/index.js
@@ -392,7 +392,7 @@ class CrawlKit {
                                 stream.write([scope.url, scope.result]);
                             }
                             queueItemFinished(err);
-                        }), this.timeout);
+                        }), this.timeout, `Worker timed out after ${this.timeout}ms.`);
 
                         async.waterfall([
                             step.acquireBrowser(scope, workerLogger, pool),

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ const phantomParamsKey = Symbol();
 const phantomPageSettingsKey = Symbol();
 const followRedirectsKey = Symbol();
 const browserCookiesKey = Symbol();
-const retriesKey = Symbol();
+const triesKey = Symbol();
 const redirectFilterKey = Symbol();
 
 /**
@@ -177,7 +177,8 @@ class CrawlKit {
     }
 
     /**
-    * Getter/setter for the number of retries when a PhantomJS instance crashes on a page.
+    * Getter/setter for the number of tries when a PhantomJS instance crashes on a page
+    * or {@link CrawlKit#timeout} is hit.
     * When a PhantomJS instance crashes whilst crawling a webpage, this instance is shutdown
     * and replaced by a new one. By default the webpage that failed in such a way will be
     * re-queued. This member controls how often that re-queueing happens.
@@ -185,24 +186,24 @@ class CrawlKit {
     * Values under zero are set to zero.
     *
     * @type {!integer}
-    * @default 3 (try 2 more times after the first failure)
+    * @default 3 (read: try two more times after the first failure, three times in total)
     */
-    set retries(n) {
-        this[retriesKey] = parseInt(n, 10);
+    set tries(n) {
+        this[triesKey] = parseInt(n, 10);
     }
 
     /**
     * @ignore
     */
-    get retries() {
-        return Math.max(0, this[retriesKey] || 3);
+    get tries() {
+        return Math.max(0, this[triesKey] || 3);
     }
 
     /**
     * Allows you to add a runner that is executed on each crawled page.
     * The returned value of the runner is added to the overall result.
     * Runners run sequentially on each webpage in the order they were added.
-    * If a runner is crashing PhantomJS more than {@link CrawlKit#retries} times, subsequent {@link Runner}s are not executed.
+    * If a runner is crashing PhantomJS more than {@link CrawlKit#tries} times, subsequent {@link Runner}s are not executed.
     *
     * @see For an example see `examples/simple.js`. For an example using parameters, see `examples/advanced.js`.
     * @param {!String} key The runner identificator. This is also used in the result stream/object.
@@ -380,7 +381,7 @@ class CrawlKit {
                             }
                             stopWorkerTimer();
                             if (err instanceof HeadlessError) {
-                                if (scope.tries < this.retries) {
+                                if (scope.tries < this.tries) {
                                     logger.info(`Retrying ${scope.url} - adding back to queue.`);
                                     delete scope.result.error;
                                     q.unshift(scope);

--- a/src/worker/steps/findLinks.js
+++ b/src/worker/steps/findLinks.js
@@ -26,11 +26,13 @@ module.exports = (scope, logger, finder, finderParameters, addUrl) => {
             return cb();
         }
 
+        const timeout = finder.timeout || Finder.DEFAULT_TIMEOUT;
         const done = callbackTimeout(once((err) => {
             logger.debug('Finder ran.');
             done.called = true;
             cb(err);
-        }), finder.timeout || Finder.DEFAULT_TIMEOUT);
+        }), timeout, `Finder timed out after ${timeout}ms.`);
+
         function phantomCallback(err, urls) {
             if (done.called) {
                 logger.debug('Callback alread called.');

--- a/src/worker/steps/findLinks.js
+++ b/src/worker/steps/findLinks.js
@@ -2,8 +2,10 @@
 const path = require('path');
 const once = require('once');
 const callbackTimeout = require('callback-timeout');
-const isPhantomError = require(path.join(__dirname, '..', '..', 'isPhantomError.js'));
-const applyUrlFilterFn = require(path.join(__dirname, '..', '..', 'applyUrlFilterFn.js'));
+const basePath = path.join(__dirname, '..', '..');
+const isPhantomError = require(path.join(basePath, 'isPhantomError.js'));
+const applyUrlFilterFn = require(path.join(basePath, 'applyUrlFilterFn.js'));
+const Finder = require(path.join(basePath, 'Finder.js'));
 
 function getFinderRunnable(finder) {
     if (!finder) {
@@ -16,7 +18,7 @@ function getUrlFilter(finder) {
     return (finder && finder.urlFilter) ? finder.urlFilter.bind(finder) : null;
 }
 
-module.exports = (scope, logger, finder, finderParameters, addUrl, timeout) => {
+module.exports = (scope, logger, finder, finderParameters, addUrl) => {
     return (cb) => {
         logger.debug('Trying to run finder.');
         if (!finder) {
@@ -28,7 +30,7 @@ module.exports = (scope, logger, finder, finderParameters, addUrl, timeout) => {
             logger.debug('Finder ran.');
             done.called = true;
             cb(err);
-        }), timeout);
+        }), finder.timeout || Finder.DEFAULT_TIMEOUT);
         function phantomCallback(err, urls) {
             if (done.called) {
                 logger.debug('Callback alread called.');

--- a/src/worker/steps/findLinks.js
+++ b/src/worker/steps/findLinks.js
@@ -1,7 +1,7 @@
 'use strict'; // eslint-disable-line
 const path = require('path');
 const once = require('once');
-const timeoutCallback = require('timeout-callback');
+const callbackTimeout = require('callback-timeout');
 const isPhantomError = require(path.join(__dirname, '..', '..', 'isPhantomError.js'));
 const applyUrlFilterFn = require(path.join(__dirname, '..', '..', 'applyUrlFilterFn.js'));
 
@@ -24,11 +24,11 @@ module.exports = (scope, logger, finder, finderParameters, addUrl, timeout) => {
             return cb();
         }
 
-        const done = timeoutCallback(timeout, once((err) => {
+        const done = callbackTimeout(once((err) => {
             logger.debug('Finder ran.');
             done.called = true;
             cb(err);
-        }));
+        }), timeout);
         function phantomCallback(err, urls) {
             if (done.called) {
                 logger.debug('Callback alread called.');

--- a/src/worker/steps/pageRunners.js
+++ b/src/worker/steps/pageRunners.js
@@ -3,7 +3,7 @@
 const debug = require('debug');
 const once = require('once');
 const path = require('path');
-const timeoutCallback = require('timeout-callback');
+const callbackTimeout = require('callback-timeout');
 const isPhantomError = require(path.join(__dirname, '..', '..', 'isPhantomError.js'));
 const HeadlessError = require('node-phantom-simple/headless_error');
 
@@ -46,7 +46,7 @@ module.exports = (scope, logger, runners, workerLogPrefix, timeout) => {
                 error: debug(`${runnerLogPrefix}:error`),
             };
 
-            const doneAndNext = timeoutCallback(timeout, once((res) => {
+            const doneAndNext = callbackTimeout(once((res) => {
                 logger.debug(`Runner '${runnerId}' finished.`);
                 let err;
                 let result;
@@ -67,7 +67,7 @@ module.exports = (scope, logger, runners, workerLogPrefix, timeout) => {
                 }
                 logger.debug('On to next runner.');
                 nextRunner();
-            }));
+            }), timeout);
 
             const runner = runnerObj.runner;
             const parameters = runnerObj.parameters;

--- a/src/worker/steps/pageRunners.js
+++ b/src/worker/steps/pageRunners.js
@@ -51,6 +51,7 @@ module.exports = (scope, logger, runners, workerLogPrefix) => {
                 error: debug(`${runnerLogPrefix}:error`),
             };
 
+            const timeout = runner.timeout || Runner.DEFAULT_TIMEOUT;
             const doneAndNext = callbackTimeout(once((res) => {
                 logger.debug(`Runner '${runnerId}' finished.`);
                 let err;
@@ -72,7 +73,7 @@ module.exports = (scope, logger, runners, workerLogPrefix) => {
                 }
                 logger.debug('On to next runner.');
                 nextRunner();
-            }), runner.timeout || Runner.DEFAULT_TIMEOUT);
+            }), timeout, `Runner timed out after ${timeout}ms.`);
 
             Promise.resolve(runner.getCompanionFiles())
             .then((companionFiles) => {

--- a/src/worker/steps/pageRunners.js
+++ b/src/worker/steps/pageRunners.js
@@ -4,10 +4,13 @@ const debug = require('debug');
 const once = require('once');
 const path = require('path');
 const callbackTimeout = require('callback-timeout');
-const isPhantomError = require(path.join(__dirname, '..', '..', 'isPhantomError.js'));
+const basePath = path.join(__dirname, '..', '..');
+const isPhantomError = require(path.join(basePath, 'isPhantomError.js'));
+const Runner = require(path.join(basePath, 'Runner.js'));
+
 const HeadlessError = require('node-phantom-simple/headless_error');
 
-module.exports = (scope, logger, runners, workerLogPrefix, timeout) => {
+module.exports = (scope, logger, runners, workerLogPrefix) => {
     return (cb) => {
         logger.debug('Trying to run page runners.');
 
@@ -37,6 +40,8 @@ module.exports = (scope, logger, runners, workerLogPrefix, timeout) => {
 
             const runnerId = next.value[0];
             const runnerObj = next.value[1];
+            const runner = runnerObj.runner;
+            const parameters = runnerObj.parameters;
 
             const runnerLogPrefix = `${workerLogPrefix}:runner(${runnerId})`;
             const runnerLogger = {
@@ -67,10 +72,7 @@ module.exports = (scope, logger, runners, workerLogPrefix, timeout) => {
                 }
                 logger.debug('On to next runner.');
                 nextRunner();
-            }), timeout);
-
-            const runner = runnerObj.runner;
-            const parameters = runnerObj.parameters;
+            }), runner.timeout || Runner.DEFAULT_TIMEOUT);
 
             Promise.resolve(runner.getCompanionFiles())
             .then((companionFiles) => {

--- a/test/index.js
+++ b/test/index.js
@@ -904,7 +904,7 @@ describe('CrawlKit', function main() {
             });
 
             it('or how many times defined', () => {
-                crawler.retries = 2;
+                crawler.tries = 2;
 
                 return crawler.crawl().then((result) => {
                     flakyRunnable.should.have.been.calledTwice;

--- a/test/index.js
+++ b/test/index.js
@@ -10,6 +10,7 @@ const auth = require('http-auth');
 const http = require('http');
 const httpProxy = require('http-proxy');
 const HeadlessError = require('node-phantom-simple/headless_error');
+const TimeoutError = require('callback-timeout/errors').TimeoutError;
 
 const pkg = require(path.join(__dirname, '..', 'package.json'));
 const CrawlKit = require(path.join(__dirname, '..', pkg.main));
@@ -207,7 +208,7 @@ describe('CrawlKit', function main() {
 
                 const results = {};
                 results[`${url}/`] = {
-                    error: new Error('callback timeout'),
+                    error: new TimeoutError('timeout of 200ms exceeded for callback anonymous'),
                 };
                 crawler.timeout = 200;
                 crawler.setFinder({ getRunnable: () => function neverReturningFilter() {} });
@@ -524,7 +525,7 @@ describe('CrawlKit', function main() {
             results[`${url}/`] = {
                 runners: {
                     x: {
-                        error: new Error('callback timeout'),
+                        error: new TimeoutError('timeout of 200ms exceeded for callback anonymous'),
                     },
                 },
             };
@@ -553,13 +554,13 @@ describe('CrawlKit', function main() {
             results[`${url}/`] = {
                 runners: {
                     x: {
-                        error: new Error('callback timeout'),
+                        error: new TimeoutError('timeout of 200ms exceeded for callback anonymous'),
                     },
                     y: {
                         result: 'success',
                     },
                     z: {
-                        error: new Error('callback timeout'),
+                        error: new TimeoutError('timeout of 200ms exceeded for callback anonymous'),
                     },
                 },
             };

--- a/test/index.js
+++ b/test/index.js
@@ -124,7 +124,7 @@ describe('CrawlKit', function main() {
             crawler.timeout = 5;
             const results = {};
             results[`${url}/`] = {
-                error: new TimeoutError('timeout of 5ms exceeded for callback anonymous'),
+                error: new TimeoutError('Worker timed out after 5ms.'),
             };
             return crawler.crawl().should.eventually.deep.equal({ results });
         });
@@ -233,7 +233,7 @@ describe('CrawlKit', function main() {
 
                     const results = {};
                     results[`${url}/`] = {
-                        error: new TimeoutError('timeout of 200ms exceeded for callback anonymous'),
+                        error: new TimeoutError('Finder timed out after 200ms.'),
                     };
 
                     crawler.setFinder({
@@ -248,7 +248,7 @@ describe('CrawlKit', function main() {
 
                     const results = {};
                     results[`${url}/`] = {
-                        error: new TimeoutError(`timeout of ${Finder.DEFAULT_TIMEOUT}ms exceeded for callback anonymous`),
+                        error: new TimeoutError(`Finder timed out after ${Finder.DEFAULT_TIMEOUT}ms.`),
                     };
 
                     crawler.setFinder({
@@ -580,7 +580,7 @@ describe('CrawlKit', function main() {
                 results[`${url}/`] = {
                     runners: {
                         x: {
-                            error: new TimeoutError('timeout of 200ms exceeded for callback anonymous'),
+                            error: new TimeoutError('Runner timed out after 200ms.'),
                         },
                     },
                 };
@@ -599,7 +599,7 @@ describe('CrawlKit', function main() {
                 results[`${url}/`] = {
                     runners: {
                         x: {
-                            error: new TimeoutError(`timeout of ${Runner.DEFAULT_TIMEOUT}ms exceeded for callback anonymous`),
+                            error: new TimeoutError(`Runner timed out after ${Runner.DEFAULT_TIMEOUT}ms.`),
                         },
                     },
                 };
@@ -610,19 +610,19 @@ describe('CrawlKit', function main() {
                 const crawler = new CrawlKit(url);
 
                 crawler.addRunner('x', {
-                    timeout: 200,
+                    timeout: 100,
                     getCompanionFiles: () => [],
                     getRunnable: () => function noop() {},
                 });
 
                 crawler.addRunner('y', {
-                    timeout: 200,
+                    timeout: 100,
                     getCompanionFiles: () => [],
                     getRunnable: () => function success() { window.callPhantom(null, 'success'); },
                 });
 
                 crawler.addRunner('z', {
-                    timeout: 200,
+                    timeout: 100,
                     getCompanionFiles: () => [],
                     getRunnable: () => function noop() {},
                 });
@@ -631,13 +631,13 @@ describe('CrawlKit', function main() {
                 results[`${url}/`] = {
                     runners: {
                         x: {
-                            error: new TimeoutError('timeout of 200ms exceeded for callback anonymous'),
+                            error: new TimeoutError('Runner timed out after 100ms.'),
                         },
                         y: {
                             result: 'success',
                         },
                         z: {
-                            error: new TimeoutError('timeout of 200ms exceeded for callback anonymous'),
+                            error: new TimeoutError('Runner timed out after 100ms.'),
                         },
                     },
                 };

--- a/test/index.js
+++ b/test/index.js
@@ -256,6 +256,24 @@ describe('CrawlKit', function main() {
                     });
                     return crawler.crawl().should.eventually.deep.equal({ results });
                 });
+
+                it('should try X times in case of timeout', () => {
+                    const crawler = new CrawlKit(url);
+                    crawler.tries = 2;
+
+                    const results = {};
+                    results[`${url}/`] = {
+                        error: new TimeoutError(`Finder timed out after ${Finder.DEFAULT_TIMEOUT}ms.`),
+                    };
+                    const spy = sinon.spy(() => function neverReturningFilter() {});
+                    crawler.setFinder({
+                        getRunnable: spy,
+                    });
+                    return crawler.crawl().then((result) => {
+                        spy.callCount.should.equal(2);
+                        return result.results;
+                    }).should.eventually.deep.equal(results);
+                });
             });
 
             it('on a page with errors', () => {


### PR DESCRIPTION
This PR fixes some timeout issues.
- Until now, runners, the overall app and finders only could have the same timeout defined.
- If the main app timed out, it was not retried.
- Timeout messages were quite unspecific

This is a breaking change:
- `.retries` has been renamed to `.tries` in order to reflect better what it really specifies
- `.timeout` specifies the overall timeout and has been changed from 10 to 30 seconds.
- each runner or finder can define a `.timeout` getter on the finder/runner object that is used for the respective function returned by `.getRunnable()`.
