### PR TITLE
fix: ignore websites returning 4xx+ status codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "docs": "jsdoc -c conf.json",
     "test": "mocha",
     "lint": "eslint .",
-    "tdd": "mocha --watch --reporter dot",
-    "test.server": "http-server test/fixtures/website/"
+    "tdd": "mocha --watch --reporter dot"
   },
   "files": [
     "src",
@@ -55,10 +54,10 @@
     "chai-as-promised": "^5.1.0",
     "eslint": "^1.10.2",
     "eslint-config-airbnb": "^2.0.0",
+    "express": "^4.13.3",
     "freeport": "^1.0.5",
     "http-auth": "^2.2.8",
     "http-proxy": "^1.12.0",
-    "http-server": "^0.8.5",
     "jsdoc": "^3.4.0",
     "mocha": "^2.3.4",
     "sinon": "^1.17.2",

--- a/src/errors.js
+++ b/src/errors.js
@@ -2,3 +2,6 @@
 const defineError = require('define-error');
 
 module.exports.TransformationError = defineError('TransformationError');
+module.exports.StatusError = defineError('StatusError', function statusError(statusText, code) {
+    this.code = code;
+});

--- a/src/worker/steps/openPage.js
+++ b/src/worker/steps/openPage.js
@@ -3,6 +3,7 @@
 const urijs = require('urijs');
 const path = require('path');
 const applyUrlFilterFn = require(path.join(__dirname, '..', '..', 'applyUrlFilterFn.js'));
+const StatusError = require(path.join(__dirname, '..', '..', 'errors.js')).StatusError;
 const once = require('once');
 
 module.exports = (scope, logger, addUrl, followRedirects, redirectFilter) => {
@@ -33,6 +34,12 @@ module.exports = (scope, logger, addUrl, followRedirects, redirectFilter) => {
                         done(e);
                     }
                 }
+            }
+        };
+
+        scope.page.onResourceReceived = (res) => {
+            if (parseInt(res.status, 10) >= 400) {
+                done(new StatusError(res.statusText, res.status));
             }
         };
 


### PR DESCRIPTION
Fixes a problem when websites would be crawled even though they are error pages
